### PR TITLE
Approve any-sync-sdk, GoLLRB, whyrusleeping/cbor for golang

### DIFF
--- a/tools/allowed-libs.json
+++ b/tools/allowed-libs.json
@@ -20,8 +20,20 @@
         "why": "Internal library"
       },
       {
+        "name": "github.com/anyproto/any-sync-sdk",
+        "why": "Internal library"
+      },
+      {
         "name": "github.com/anyproto/go-chash",
         "why": "Internal library"
+      },
+      {
+        "name": "github.com/petar/GoLLRB",
+        "why": "https://github.com/petar/GoLLRB/blob/master/LICENSE"
+      },
+      {
+        "name": "github.com/whyrusleeping/cbor",
+        "why": "https://github.com/whyrusleeping/cbor/blob/master/LICENSE"
       },
       {
         "name": "github.com/AndreasBriese/bbloom",


### PR DESCRIPTION
The `any-sync-filenode2` license check ([failing run](https://github.com/anyproto/any-sync-filenode2/actions/runs/28792978684)) flags three new dependencies:

- `github.com/anyproto/any-sync-sdk` — internal anyproto library (private repo, hence "unknown")
- `github.com/petar/GoLLRB` — [BSD-3-Clause](https://github.com/petar/GoLLRB/blob/master/LICENSE)
- `github.com/whyrusleeping/cbor` — [Apache-2.0](https://github.com/whyrusleeping/cbor/blob/master/LICENSE); the LICENSE file contains only the short Apache notice, so license detection reports "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)